### PR TITLE
babel-runtime required for module to run

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Calculating a position using distances from points.",
   "main": "lib/index.js",
   "dependencies": {
-    "invariant": "^2.1.0"
+    "invariant": "^2.1.0",
+    "babel-runtime": "^5.8.3"
   },
   "devDependencies": {
     "babel": "^5.8.3",


### PR DESCRIPTION
You may need to double check this, but I first ran into issues running this module until I installed babel-runtime. This should fix that.